### PR TITLE
Fix typo causing shell error in debug build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -255,7 +255,7 @@ RUN locale-gen ja_JP.UTF-8 \
 
 # .NET SDK 9.0のインストール（デバッグモードの場合のみ）
 RUN if [ "$BUILD_MODE" = "debug" ]; then \
-        && apt add-apt-repository ppa:dotnet/backports \
+        apt add-apt-repository ppa:dotnet/backports \
         && apt update \
         && apt install -y dotnet-sdk-9.0 \
         && rm -rf /var/lib/apt/lists/*; \


### PR DESCRIPTION
This pull request makes a minor fix to the `docker/Dockerfile` by correcting the conditional installation of the .NET SDK 9.0 for debug builds.

* Fixed the conditional command by removing an unnecessary `&&` before `apt add-apt-repository ppa:dotnet/backports` to ensure proper execution during debug builds.

<details>
<summary>Log: `docker compose build`</summary>

```
 => ERROR [runtime  4/15] RUN if [ "release" = "debug" ]; then         && apt add-apt-repository ppa:dotnet/backports         && apt update         && apt install -y dotnet-sdk-9.0        0.2s
------
 > [runtime  4/15] RUN if [ "release" = "debug" ]; then         && apt add-apt-repository ppa:dotnet/backports         && apt update         && apt install -y dotnet-sdk-9.0         && rm -rf /var/lib/apt/lists/*;     fi:
0.171 /bin/sh: 1: Syntax error: "&&" unexpected
------
Dockerfile:257

--------------------

 256 |     # .NET SDK 9.0のインストール（デバッグモードの場合のみ）

 257 | >>> RUN if [ "$BUILD_MODE" = "debug" ]; then \

 258 | >>>         && apt add-apt-repository ppa:dotnet/backports \

 259 | >>>         && apt update \

 260 | >>>         && apt install -y dotnet-sdk-9.0 \

 261 | >>>         && rm -rf /var/lib/apt/lists/*; \

 262 | >>>     fi

 263 |

--------------------

failed to solve: process "/bin/sh -c if [ \"$BUILD_MODE\" = \"debug\" ]; then         && apt add-apt-repository ppa:dotnet/backports         && apt update         && apt install -y dotnet-sdk-9.0         && rm -rf /var/lib/apt/lists/*;     fi" did not complete successfully: exit code: 2
```

</details>