### PR TITLE
--outdir 未指定時に QueueThread がエラー終了し、それ以降は無反応になる問題を修正

### DIFF
--- a/AmatsukazeServer/Server/QueueManager.cs
+++ b/AmatsukazeServer/Server/QueueManager.cs
@@ -487,7 +487,7 @@ namespace Amatsukaze.Server
                                         Mode = req.Mode,
                                         SrcPath = additem.Path,
                                         Hash = additem.Hash,
-                                        DstPath = Path.Combine(outitem.DstPath, outname),
+                                        DstPath = Path.Combine(outitem.DstPath ?? "", outname),
                                         StreamFormat = (VideoStreamFormat)prog.Stream,
                                         ServiceId = prog.ServiceId,
                                         ImageWidth = prog.Width,


### PR DESCRIPTION
## 概要

`AmatsukazeAddTask.exe` で `--outdir`（出力先ディレクトリ）を指定せずにタスクを追加してしまうと、サーバー側の `QueueThread` が `ArgumentNullException` を投げて異常終了してしまい、それ以降のキュー操作が無反応になった問題を修正します。

## 内容

`--outdir` を省略した場合、クライアントから送られる `outitem.DstPath` が `null` になりました。

`QueueManager.AddQueue` 内で出力先パスを組み立てる下記の処理で、`Path.Combine` の第1引数が `null` のため `ArgumentNullException`（`Parameter 'path1'`）が発生しました。

```csharp
DstPath = Path.Combine(outitem.DstPath, outname),
```

> [!NOTE] Claudeによる説明
> この例外は `EncodeServer.QueueThread` の `while` ループの外側の `catch` で捕捉されるため、一度発生するとループを抜けてスレッドが停止します。その後も TCP サーバーは接続を受け付け続けますが、キューが処理されないため `AmatsukazeAddTask.exe` の操作（タスク追加・リトライ等）が毎回タイムアウト（「サーバーのレスポンスを受理を確認できませんでした」）します。
> 
> サーバーログ (`data/Server.log`) には次の例外が出力されます。
> ```
> QueueThreadがエラー終了しました: Value cannot be null. (Parameter 'path1')
> ```

## 再現手順

1. `--outdir` を指定せずに、正しい TS ファイルを指定してタスクを追加する。
   ```
   AmatsukazeAddTask.exe -ip "127.0.0.1" -p 32768 -f "D:\path\to\real_video.ts"
   ```
2. サーバーログ (`data/Server.log`) に前述の例外が出力されて `QueueThread` が停止する。
3. 以降、タスク追加やリトライなどのコマンドがレスポンスを返さずタイムアウトする。

## 修正内容

`Path.Combine` の第1引数に null 合体演算子 (`??`) でフォールバック（空文字列）を設定しました。`Path.Combine("", outname)` は `outname` を返すため例外は発生せず、出力ディレクトリ未指定でもクラッシュを回避してキューとして処理できます。

```diff
- DstPath = Path.Combine(outitem.DstPath, outname),
+ DstPath = Path.Combine(outitem.DstPath ?? "", outname),
```
