### PR TITLE
TrimAdjust ページのモバイル表示を改善するプルリクエストです。

### DIFF
--- a/AmatsukazeWebUI/Pages/TrimAdjust.razor
+++ b/AmatsukazeWebUI/Pages/TrimAdjust.razor
@@ -49,8 +49,11 @@
         <div class="trim-main">
             @* 左: 編集点リスト *@
             <div class="trim-editpoints">
-                <div class="trim-editpoints-header">編集点</div>
-                <div class="trim-editpoints-list">
+                <div class="trim-editpoints-header" @onclick="ToggleMobileEp">
+                    <span>編集点</span>
+                    <span class="trim-ep-toggle-arrow">@(_mobileEpOpen ? "▲" : "▼")</span>
+                </div>
+                <div class="trim-editpoints-list @(_mobileEpOpen ? "mob-open" : "")">
                     @{
                         var segments = BuildEditPointSegments();
                     }
@@ -66,7 +69,7 @@
                         </div>
                     }
                 </div>
-                <div class="trim-editpoints-actions">
+                <div class="trim-editpoints-actions @(_mobileEpOpen ? "mob-open" : "")">
                     <div class="trim-editpoints-total">
                         <span class="trim-editpoints-total-label">本編 合計</span>
                         <span class="trim-editpoints-total-time">@GetActiveTotalTime()</span>
@@ -435,6 +438,7 @@
     private List<EditPoint> _editPoints = new List<EditPoint>();
     private List<EditPoint> _initialEditPoints = new List<EditPoint>(); // 初期ロード時の編集点（リセット用）
     private int _selectedEditPoint = -1;
+    private bool _mobileEpOpen;
 
     // プロファイル選択・再投入
     private List<string> _profiles = new List<string>();
@@ -1491,6 +1495,8 @@
     }
 
     // 編集点の切替（なければ追加、あれば削除）
+    private void ToggleMobileEp() => _mobileEpOpen = !_mobileEpOpen;
+
     private void ToggleEditPoint()
     {
         var existing = _editPoints.FindIndex(e => e.Frame == _currentFrame);

--- a/AmatsukazeWebUI/Pages/TrimAdjust.razor
+++ b/AmatsukazeWebUI/Pages/TrimAdjust.razor
@@ -438,7 +438,7 @@
     private List<EditPoint> _editPoints = new List<EditPoint>();
     private List<EditPoint> _initialEditPoints = new List<EditPoint>(); // 初期ロード時の編集点（リセット用）
     private int _selectedEditPoint = -1;
-    private bool _mobileEpOpen;
+    private bool _mobileEpOpen = true;
 
     // プロファイル選択・再投入
     private List<string> _profiles = new List<string>();

--- a/AmatsukazeWebUI/Pages/TrimAdjust.razor.css
+++ b/AmatsukazeWebUI/Pages/TrimAdjust.razor.css
@@ -963,3 +963,84 @@
         border: 1px solid #bdd4e9;
     }
 }
+
+/* モバイル (≤640px): アコーディオンレイアウト */
+@media (max-width: 640px) {
+    /* ツールバー: プロファイル行を2行目に折り返し */
+    .trim-toolbar {
+        flex-wrap: wrap;
+    }
+
+    .trim-toolbar-requeue {
+        flex-basis: 100%;
+        margin-left: 0;
+        order: 10;
+    }
+
+    /* メインを縦積みに変換、編集点を下部に移動 */
+    .trim-main {
+        flex-direction: column;
+    }
+
+    .trim-editpoints {
+        order: 2;
+        width: 100%;
+        min-width: 0;
+        border-right: none;
+        border-top: 1px solid #444;
+        height: auto;
+    }
+
+    .trim-preview-area {
+        order: 1;
+    }
+
+    /* 編集点ヘッダー: アコーディオントグル */
+    .trim-editpoints-header {
+        cursor: pointer;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 9px 12px;
+        user-select: none;
+        -webkit-user-select: none;
+    }
+
+    /* リスト: 折りたたみ ↔ 展開 */
+    .trim-editpoints-list {
+        flex: none;
+        max-height: 0;
+        overflow: hidden;
+        transition: max-height 0.25s ease;
+    }
+
+    .trim-editpoints-list.mob-open {
+        max-height: 180px;
+        overflow-y: auto;
+    }
+
+    /* アクション: 折りたたみ ↔ 展開 */
+    .trim-editpoints-actions {
+        display: none;
+    }
+
+    .trim-editpoints-actions.mob-open {
+        display: flex;
+    }
+
+    /* 波形の高さを縮小 */
+    .trim-waveform-container {
+        height: 44px;
+    }
+
+    .trim-waveform-img {
+        height: 44px;
+    }
+}
+
+/* PC (>640px): 矢印インジケーターは非表示 */
+@media (min-width: 641px) {
+    .trim-ep-toggle-arrow {
+        display: none;
+    }
+}

--- a/AmatsukazeWebUI/wwwroot/index.html
+++ b/AmatsukazeWebUI/wwwroot/index.html
@@ -385,6 +385,49 @@
             document.addEventListener('mouseup', function () {
                 if (dragging) { dragging = false; setHighlight(null); container.style.cursor = ''; }
             });
+            // タッチ対応（Android等）
+            function calcRatioTouch(e) {
+                if (!e.touches || !e.touches.length) return -1;
+                var rect = seekbar.getBoundingClientRect();
+                if (rect.width <= 0) return -1;
+                var r = (e.touches[0].clientX - rect.left) / rect.width;
+                return Math.max(0, Math.min(1, r));
+            }
+            function findNearestMarkerTouch(e) {
+                if (!e.touches || !e.touches.length) return null;
+                var markers = seekbar.querySelectorAll('.trim-seekbar-marker');
+                if (!markers.length) return null;
+                var touchX = e.touches[0].clientX;
+                var best = null, bestDist = Infinity;
+                for (var i = 0; i < markers.length; i++) {
+                    var mr = markers[i].getBoundingClientRect();
+                    var cx = mr.left + mr.width / 2;
+                    var dist = Math.abs(touchX - cx);
+                    if (dist < bestDist) { bestDist = dist; best = markers[i]; }
+                }
+                return (bestDist <= 30) ? best : null;
+            }
+            container.addEventListener('touchstart', function (e) {
+                if (e.touches.length !== 1) return;
+                var r = calcRatioTouch(e);
+                if (r < 0) return;
+                var marker = findNearestMarkerTouch(e);
+                if (marker) {
+                    dotNetRef.invokeMethodAsync('OnSeekBarMarkerClick', r);
+                } else {
+                    dragging = true;
+                    dotNetRef.invokeMethodAsync('OnSeekBarDrag', r);
+                }
+                e.preventDefault();
+            }, { passive: false });
+            container.addEventListener('touchmove', function (e) {
+                if (!dragging || e.touches.length !== 1) return;
+                var r = calcRatioTouch(e);
+                if (r >= 0) dotNetRef.invokeMethodAsync('OnSeekBarDrag', r);
+                e.preventDefault();
+            }, { passive: false });
+            container.addEventListener('touchend', function () { dragging = false; });
+            container.addEventListener('touchcancel', function () { dragging = false; });
         };
         // Trim調整: マウスホイールで1フレームずつ移動
         window.trimAdjustSetupWheel = function (dotNetRef) {


### PR DESCRIPTION
## 変更内容

### レイアウト（CSS メディアクエリ、≤640px のみ適用）
- 編集点パネルをアコーディオン形式に変更（ヘッダータップで開閉）
- `flex-direction: column` によりプレビューエリアを上、編集点パネルを下に配置
- PC レイアウト（≥641px）への影響はありません

### タッチ操作
- シークバーに `touchstart` / `touchmove` / `touchend` / `touchcancel` イベントを追加
- マーカー付近（30px 以内）のタップはマーカー選択、それ以外はシーク操作に振り分け

## 動作確認
- Android 実機（Chrome）で動作確認済み
- iPhone は未所持のため、Chrome DevTools のデバイスエミュレーションで表示確認済み

ビルド済み成果物:
https://github.com/kiyuu/Amatsukaze/actions/runs/27109567288

ご確認よろしくお願いいたします。