### PR TITLE
TrimAdjust: モバイルで本編合計時間を常時表示

### DIFF
--- a/AmatsukazeWebUI/Pages/TrimAdjust.razor.css
+++ b/AmatsukazeWebUI/Pages/TrimAdjust.razor.css
@@ -1019,13 +1019,11 @@
         overflow-y: auto;
     }
 
-    /* アクション: 折りたたみ ↔ 展開 */
-    .trim-editpoints-actions {
-        display: none;
-    }
-
-    .trim-editpoints-actions.mob-open {
-        display: flex;
+    /* 合計時間を横並びに（モバイルはスペース節約） */
+    .trim-editpoints-total {
+        flex-direction: row;
+        align-items: baseline;
+        gap: 8px;
     }
 
     /* 波形の高さを縮小 */


### PR DESCRIPTION
モバイルレイアウトで編集点リストを折りたたんでも
「本編 合計」時間が常に表示されるように変更。
合計時間はモバイルでは横並び表示でスペースを節約。