### PR TITLE
TrimAdjust ページのモバイルUIを改善するPR。（アコーディオン初期状態・合計時間表示）

### DIFF
--- a/AmatsukazeWebUI/Pages/TrimAdjust.razor
+++ b/AmatsukazeWebUI/Pages/TrimAdjust.razor
@@ -438,7 +438,7 @@
     private List<EditPoint> _editPoints = new List<EditPoint>();
     private List<EditPoint> _initialEditPoints = new List<EditPoint>(); // 初期ロード時の編集点（リセット用）
     private int _selectedEditPoint = -1;
-    private bool _mobileEpOpen = true;
+    private bool _mobileEpOpen = false;
 
     // プロファイル選択・再投入
     private List<string> _profiles = new List<string>();

--- a/AmatsukazeWebUI/Pages/TrimAdjust.razor.css
+++ b/AmatsukazeWebUI/Pages/TrimAdjust.razor.css
@@ -1019,13 +1019,11 @@
         overflow-y: auto;
     }
 
-    /* アクション: 折りたたみ ↔ 展開 */
-    .trim-editpoints-actions {
-        display: none;
-    }
-
-    .trim-editpoints-actions.mob-open {
-        display: flex;
+    /* 合計時間を横並びに（モバイルはスペース節約） */
+    .trim-editpoints-total {
+        flex-direction: row;
+        align-items: baseline;
+        gap: 8px;
     }
 
     /* 波形の高さを縮小 */


### PR DESCRIPTION
## 変更内容

### 編集点アコーディオン・合計時間表示
- モバイル表示時、編集点アコーディオンの初期状態を「展開」から「折りたたみ」に変更
  （編集点数によりTSプレビュー画面の大きさ・位置が可変になり、初期表示の位置が固定されないため）
- 本編合計時間の表示をアコーディオンの外に移動し、開閉状態によらず常時表示されるように変更

## 動作確認
- Android 実機で動作確認済み
- iPhone は未所持のため、ブラウザのデバイスエミュレーション機能で iOS 表示を確認済み

ビルド済み成果物:
https://github.com/kiyuu/Amatsukaze/actions/runs/31368548708

ご確認よろしくお願いいたします。