### PR TITLE
TrimAdjust ナビゲーションボタンに長押しリピート機能を追加

### DIFF
--- a/AmatsukazeWebUI/Pages/TrimAdjust.razor
+++ b/AmatsukazeWebUI/Pages/TrimAdjust.razor
@@ -163,7 +163,10 @@
                         <span class="trim-control-distance">@GetTrimCommandDistanceLabel(TrimCmdPrevEditPoint)</span>
                     </button>
                     <button class="trim-control-btn"
-                            @onclick="() => ExecuteTrimCommand(TrimCmdBack4)"
+                            @onpointerdown="e => OnRepeatBtnDown(e, TrimCmdBack4)"
+                            @onpointerup="OnRepeatBtnUp"
+                            @onpointercancel="OnRepeatBtnUp"
+                            @onpointerleave="OnRepeatBtnUp"
                             title="@GetTrimCommandTooltip(TrimCmdBack4)"
                             aria-label="@GetTrimCommandTooltip(TrimCmdBack4)">
                         <span class="trim-control-icon trim-control-icon-left">
@@ -175,7 +178,10 @@
                         <span class="trim-control-distance">@GetTrimCommandDistanceLabel(TrimCmdBack4)</span>
                     </button>
                     <button class="trim-control-btn"
-                            @onclick="() => ExecuteTrimCommand(TrimCmdBack3)"
+                            @onpointerdown="e => OnRepeatBtnDown(e, TrimCmdBack3)"
+                            @onpointerup="OnRepeatBtnUp"
+                            @onpointercancel="OnRepeatBtnUp"
+                            @onpointerleave="OnRepeatBtnUp"
                             title="@GetTrimCommandTooltip(TrimCmdBack3)"
                             aria-label="@GetTrimCommandTooltip(TrimCmdBack3)">
                         <span class="trim-control-icon trim-control-icon-left">
@@ -186,7 +192,10 @@
                         <span class="trim-control-distance">@GetTrimCommandDistanceLabel(TrimCmdBack3)</span>
                     </button>
                     <button class="trim-control-btn"
-                            @onclick="() => ExecuteTrimCommand(TrimCmdBack2)"
+                            @onpointerdown="e => OnRepeatBtnDown(e, TrimCmdBack2)"
+                            @onpointerup="OnRepeatBtnUp"
+                            @onpointercancel="OnRepeatBtnUp"
+                            @onpointerleave="OnRepeatBtnUp"
                             title="@GetTrimCommandTooltip(TrimCmdBack2)"
                             aria-label="@GetTrimCommandTooltip(TrimCmdBack2)">
                         <span class="trim-control-icon trim-control-icon-left">
@@ -196,7 +205,10 @@
                         <span class="trim-control-distance">@GetTrimCommandDistanceLabel(TrimCmdBack2)</span>
                     </button>
                     <button class="trim-control-btn"
-                            @onclick="() => ExecuteTrimCommand(TrimCmdBack1)"
+                            @onpointerdown="e => OnRepeatBtnDown(e, TrimCmdBack1)"
+                            @onpointerup="OnRepeatBtnUp"
+                            @onpointercancel="OnRepeatBtnUp"
+                            @onpointerleave="OnRepeatBtnUp"
                             title="@GetTrimCommandTooltip(TrimCmdBack1)"
                             aria-label="@GetTrimCommandTooltip(TrimCmdBack1)">
                         <span class="trim-control-icon trim-control-icon-left">
@@ -215,7 +227,10 @@
                         <span class="trim-control-distance">@GetTrimCommandDistanceLabel(TrimCmdToggleEditPoint)</span>
                     </button>
                     <button class="trim-control-btn"
-                            @onclick="() => ExecuteTrimCommand(TrimCmdForward1)"
+                            @onpointerdown="e => OnRepeatBtnDown(e, TrimCmdForward1)"
+                            @onpointerup="OnRepeatBtnUp"
+                            @onpointercancel="OnRepeatBtnUp"
+                            @onpointerleave="OnRepeatBtnUp"
                             title="@GetTrimCommandTooltip(TrimCmdForward1)"
                             aria-label="@GetTrimCommandTooltip(TrimCmdForward1)">
                         <span class="trim-control-icon trim-control-icon-right">
@@ -224,7 +239,10 @@
                         <span class="trim-control-distance">@GetTrimCommandDistanceLabel(TrimCmdForward1)</span>
                     </button>
                     <button class="trim-control-btn"
-                            @onclick="() => ExecuteTrimCommand(TrimCmdForward2)"
+                            @onpointerdown="e => OnRepeatBtnDown(e, TrimCmdForward2)"
+                            @onpointerup="OnRepeatBtnUp"
+                            @onpointercancel="OnRepeatBtnUp"
+                            @onpointerleave="OnRepeatBtnUp"
                             title="@GetTrimCommandTooltip(TrimCmdForward2)"
                             aria-label="@GetTrimCommandTooltip(TrimCmdForward2)">
                         <span class="trim-control-icon trim-control-icon-right">
@@ -234,7 +252,10 @@
                         <span class="trim-control-distance">@GetTrimCommandDistanceLabel(TrimCmdForward2)</span>
                     </button>
                     <button class="trim-control-btn"
-                            @onclick="() => ExecuteTrimCommand(TrimCmdForward3)"
+                            @onpointerdown="e => OnRepeatBtnDown(e, TrimCmdForward3)"
+                            @onpointerup="OnRepeatBtnUp"
+                            @onpointercancel="OnRepeatBtnUp"
+                            @onpointerleave="OnRepeatBtnUp"
                             title="@GetTrimCommandTooltip(TrimCmdForward3)"
                             aria-label="@GetTrimCommandTooltip(TrimCmdForward3)">
                         <span class="trim-control-icon trim-control-icon-right">
@@ -245,7 +266,10 @@
                         <span class="trim-control-distance">@GetTrimCommandDistanceLabel(TrimCmdForward3)</span>
                     </button>
                     <button class="trim-control-btn"
-                            @onclick="() => ExecuteTrimCommand(TrimCmdForward4)"
+                            @onpointerdown="e => OnRepeatBtnDown(e, TrimCmdForward4)"
+                            @onpointerup="OnRepeatBtnUp"
+                            @onpointercancel="OnRepeatBtnUp"
+                            @onpointerleave="OnRepeatBtnUp"
                             title="@GetTrimCommandTooltip(TrimCmdForward4)"
                             aria-label="@GetTrimCommandTooltip(TrimCmdForward4)">
                         <span class="trim-control-icon trim-control-icon-right">
@@ -457,6 +481,9 @@
     private string? _queueItemOutDir; // 再投入時の出力先フォルダ
     private int _queueItemPriority = 3; // 再投入時に引き継ぐ優先度
     private List<string>? _queueItemTags; // 再投入時に引き継ぐタグ（CM解析投入時と同一）
+
+    // 長押しリピート用
+    private CancellationTokenSource? _repeatCts;
 
     // debounce用タイマー
     private System.Threading.Timer? _debounceTimer;
@@ -1731,6 +1758,65 @@
         StateHasChanged();
     }
 
+    private void OnRepeatBtnDown(PointerEventArgs e, string commandId)
+    {
+        if (e.IsPrimary) StartRepeat(commandId);
+    }
+
+    private void OnRepeatBtnUp(PointerEventArgs e)
+    {
+        if (e.IsPrimary) StopRepeat();
+    }
+
+    private void StartRepeat(string commandId)
+    {
+        StopRepeat();
+        ExecuteTrimCommand(commandId);
+        _repeatCts = new CancellationTokenSource();
+        var token = _repeatCts.Token;
+        _ = RepeatAsync(commandId, token);
+    }
+
+    private async Task RepeatAsync(string commandId, CancellationToken token)
+    {
+        try
+        {
+            await Task.Delay(400, token);
+            var intervalMs = GetRepeatIntervalMs(commandId);
+            while (!token.IsCancellationRequested)
+            {
+                await InvokeAsync(() =>
+                {
+                    if (!token.IsCancellationRequested)
+                    {
+                        ExecuteTrimCommand(commandId);
+                        StateHasChanged();
+                    }
+                });
+                await Task.Delay(intervalMs, token);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+        }
+    }
+
+    private static int GetRepeatIntervalMs(string commandId) => commandId switch
+    {
+        TrimCmdBack1    or TrimCmdForward1 => 10,
+        TrimCmdBack2    or TrimCmdForward2 => 100,
+        TrimCmdBack3    or TrimCmdForward3 => 100,
+        TrimCmdBack4    or TrimCmdForward4 => 100,
+        _                                  => 100
+    };
+
+    private void StopRepeat()
+    {
+        _repeatCts?.Cancel();
+        _repeatCts?.Dispose();
+        _repeatCts = null;
+    }
+
     private void ExecuteTrimCommand(string commandId)
     {
         switch (commandId)
@@ -2080,6 +2166,7 @@
 
     public async ValueTask DisposeAsync()
     {
+        StopRepeat();
         _debounceTimer?.Dispose();
         _objRef?.Dispose();
         if (!string.IsNullOrEmpty(_sessionId))

--- a/AmatsukazeWebUI/Pages/TrimAdjust.razor.css
+++ b/AmatsukazeWebUI/Pages/TrimAdjust.razor.css
@@ -193,6 +193,8 @@
     overflow: hidden;
     padding: 8px;
     gap: 6px;
+    user-select: none;
+    -webkit-user-select: none;
 }
 
 .trim-preview-container {
@@ -385,7 +387,7 @@
     justify-content: center;
     gap: 4px;
     transition: transform 120ms ease, box-shadow 120ms ease, background 120ms ease;
-    touch-action: manipulation;
+    touch-action: none;
 }
 
 .trim-control-btn:hover {


### PR DESCRIPTION
## 変更内容

### ナビゲーションボタンの長押しリピート
- <<<<〜>>>> の8方向ボタンについて、押しっぱなし中はフレーム移動を連続実行するリピート機能を追加（押下から400ms後にリピート開始）
- ±1フレームボタンは10ms間隔（キーリピート相当）、それ以外のボタンは100ms間隔でリピート
- pointerdown/pointerup/pointercancel/pointerleave イベントで制御
- touch-action: none を指定し、モバイルでの pointercancel 誤発火を防止
- プレビューエリアに user-select: none を追加し、長押し時にテキスト選択メニューが表示されるのを抑制

## 動作確認
- Android 実機で動作確認済み
- iPhone は未所持のため、ブラウザのデバイスエミュレーション機能で iOS 表示を確認済み

ビルド済み成果物:
https://github.com/kiyuu/Amatsukaze/actions/runs/31368548708

ご確認よろしくお願いいたします。