### PR TITLE
WebUIのエンコード後動作設定がスリープキャンセル通知で上書きされる不具合を修正

### DIFF
--- a/AmatsukazeServer/Server/Rest/RestStateStore.cs
+++ b/AmatsukazeServer/Server/Rest/RestStateStore.cs
@@ -1565,10 +1565,6 @@ namespace Amatsukaze.Server.Rest
                 {
                     EnsureTaskConsoleMapping(data.EncodeState.ConsoleId);
                 }
-                if (data.SleepCancel != null)
-                {
-                    finishSetting = ServerSupport.DeepCopy(data.SleepCancel);
-                }
             }
             return Task.FromResult(0);
         }


### PR DESCRIPTION
## Summary
- `RestStateStore.OnUIData` が、WPFアプリのキャンセルポップアップ専用の一時通知 `SleepCancel` を、`GET /api/system` がWebUIに返す `finishSetting`（保存された設定値）と同じフィールドに無条件で上書きしていました
- `CancelSleep` は新しい録画がキューに積まれるたびに呼ばれ、その際 `Action=None` の空データを流すため、実際の設定（`AppData_.finishSetting`）は変わっていないのにWebUI上は常に「何もしない」に戻って見える不具合が発生していました

## Changes
- `RestStateStore.OnUIData` から `SleepCancel` による `finishSetting` の上書き処理を削除

## Test plan
- [x] WebUIでエンコード後動作を設定 → 新規録画がキューに積まれても表示が保持されることを確認