### PR TITLE
mp4の字幕muxで-tightを指定し、字幕がファイル前方に偏るのを修正

### DIFF
--- a/Amatsukaze/TranscodeSetting.cpp
+++ b/Amatsukaze/TranscodeSetting.cpp
@@ -8,6 +8,7 @@
 
 #include "TranscodeSetting.h"
 #include "EncoderOptionParser.h"
+#include <algorithm>
 #include <cmath>
 
 // カラースペース定義を使うため
@@ -406,6 +407,13 @@ static std::string escapeXmlAttr(const std::string& s) {
     return ret;
 }
 
+// mp4にmuxされる字幕(tx3g)があるかどうか
+// ASS/WebVTT/NicoJKはmp4には入れず別ファイルとして出力するため、対象はSRTのみ
+static bool hasMp4Subtitles(const std::vector<tstring>& subsTitles) {
+    return std::any_of(subsTitles.begin(), subsTitles.end(),
+        [](const tstring& title) { return title == _T("SRT"); });
+}
+
 /* static */ std::vector<std::pair<tstring, bool>> makeMuxerArgs(
     const ENUM_ENCODER encoder,
     const std::pair<int, int>& userSAR,
@@ -444,10 +452,20 @@ static std::string escapeXmlAttr(const std::string& s) {
         bool needChapter = (chapterpath.size() > 0);
         bool needSubs = (inSubs.size() > 0);
         const bool needTimecode = (timecodepath.size() > 0);
+        // 字幕(tx3g)を入れる場合は -tight (サンプル単位インターリーブ) を指定する
+        // mp4boxの既定は0.5秒単位のインターリーブだが、1サンプルが数秒ある字幕のような
+        // 疎なトラックは「1周につき1サンプル」書き出されるため、映像より大幅に先行して
+        // ファイル前方に偏る。この状態でシークすると、プレイヤーが字幕を取りに行くために
+        // 数百MB単位の逆方向シークを繰り返し、字幕の更新が数秒〜数十秒止まる
+        const bool tightInterleave = hasMp4Subtitles(subsTitles);
 
         sb.clear();
         sb.append(_T("\"%s\""), mp4boxpath);
         sb.append(_T(" -brand mp42 -ab mp41 -ab iso2"));
+        // timecodeがない場合は、この呼び出しが字幕入りの最終出力を書く
+        if (tightInterleave && !needTimecode) {
+            sb.append(_T(" -tight"));
+        }
         sb.append(_T(" -tmp \"%s\""), tmpdir);
         sb.append(_T(" -add \"%s#video:name=Video:forcesync"), inVideo);
         if (!encoderOutputInContainer) {
@@ -504,6 +522,10 @@ static std::string escapeXmlAttr(const std::string& s) {
         if (needChapter || needSubs) {
             // 字幕とチャプターを埋め込む
             sb.append(_T("\"%s\" -brand mp42 -ab mp41 -ab iso2"), mp4boxpath);
+            // timecodeがある場合は、こちらが字幕入りの最終出力を書く
+            if (tightInterleave) {
+                sb.append(_T(" -tight"));
+            }
             sb.append(_T(" -add \"%s\""), dst);
             sb.append(_T(" -tmp \"%s\""), tmpdir);
             for (int i = 0; i < (int)inSubs.size(); i++) {


### PR DESCRIPTION
#26 の修正です。

## 概要

mp4box の既定のインターリーブ（0.5 秒）では、1 サンプルが数秒ある字幕トラックが「窓に収まらなくても 1 個は書く」というエスケープに落ち、1 ラウンドにつき 1 個ずつ進んでファイル前方に偏ります。

字幕が実際に mux される mp4box の呼び出しにのみ `-tight`（サンプル単位のインターリーブ）を指定するようにしました。

## 変更内容

`Amatsukaze/TranscodeSetting.cpp` の 1 ファイル、22 行の追加のみです。

- `hasMp4Subtitles()` を追加しました。mp4 に `-add` されるのは SRT のみ（ASS / WebVTT / NicoJK は別ファイルとして出力）なので、`subsTitles` に `SRT` が含まれるかで判定しています。
- MP4 分岐の先頭で `tightInterleave` を決め、**字幕入りの最終出力を書く呼び出しにだけ**付与します。

mp4box の呼び出しは 2 箇所ありますが、字幕が入るのは常にどちらか一方だけです。

| ケース | 1 回目 | 2 回目 | `-tight` |
|---|---|---|---|
| timecode なし・SRT あり | `outpath` を書く | 走らない | 1 回目 |
| timecode あり・SRT あり | `tmpout1path` | `outpath` を書く | 2 回目 |
| timecode あり・チャプターのみ | `tmpout1path` | `outpath` を書く | 付けない |
| 字幕もチャプターも無し | `outpath` を書く | 走らない | 付けない |

`!needTimecode` のときは `needChapter` / `needSubs` が両方落ちるため `dst` が必ず `outpath` になり、逆に 2 回目は `needTimecode` のときしか走りません。両者は排他なのでフラグ 1 つで振り分けています。

## 字幕があるときだけに限定した理由

`-tight` は全トラックを DTS 順に並べ直すため、チャンク数がサンプル数に近づき moov が肥大します（今回の測定で約 1.7 倍、1.4 → 2.3 MB）。この増分はほぼ全部が映像と音声の交替によるもので、映像・音声のみのファイルに付けても**同じコストを払って得るものがありません**。

なおチャプターは `-chap` に `.txt` を渡すため GPAC 側で `moov/udta` の `chpl` ボックスになり、トラックでもサンプルでもないため対象外としています。

## 検証

- このコードでコンテナ版をビルドし、運用環境で稼働させています（2026-08-30 〜）
- **字幕あり / なしの両方の TS で、`-tight` が正しく選択されていることを moov を見て確認**しています

TSREPLACE 出力は字幕を持たないため対象外、MKV 出力は mkvmerge 経由なので影響ありません。

## 補足

`AmatsukazeUnitTest/` は AGENTS.md で「改造版では開発/変更は行わない」とされているため、テストの追加は行っていません。

他に確認すべき点がありましたらお知らせください。手元の環境で試します。
